### PR TITLE
Get Faraday SSL verify mode setting from PDC config.

### DIFF
--- a/lib/pdc/config.rb
+++ b/lib/pdc/config.rb
@@ -108,7 +108,9 @@ module PDC
       # resets and returns the +Faraday+ +connection+ object
       def reset_base_connection
         headers = PDC::Request.default_headers
-        PDC::Base.connection = Faraday.new(url: api_url, headers: headers) do |c|
+        PDC::Base.connection = Faraday.new(
+          url: api_url, headers: headers,
+          :ssl => {:verify => (config.ssl_verify_mode == OpenSSL::SSL::VERIFY_PEER)}) do |c|
           c.request   :append_slash_to_path
           c.request   :authorization, 'Token', token if config.requires_token
 


### PR DESCRIPTION
When ssl verify mode is set to OpenSSL::SSL::VERIFY_PEER
or not in config, Faraday ssl verify mode should
be consistent with this setting.

JIRA: PDC-1687