### PR TITLE
Defer fetching token on first request

### DIFF
--- a/lib/pdc/http/request.rb
+++ b/lib/pdc/http/request.rb
@@ -1,4 +1,6 @@
+require 'pdc/http/request/token_fetcher'
 require 'pdc/http/request/append_slash'
+require 'pdc/http/request/pdc_token'
 
 module PDC
   module Request

--- a/lib/pdc/http/request/pdc_token.rb
+++ b/lib/pdc/http/request/pdc_token.rb
@@ -1,0 +1,30 @@
+module PDC::Request
+
+  # Adds TokenAuthentication to request header. Uses the token if passed
+  # else fetches token using the TokenFetcher to get the token once
+  class Token < Faraday::Middleware
+    include PDC::Logging
+
+    Faraday::Request.register_middleware pdc_token: self
+
+    def initialize(app, options = {})
+      @options = options
+      super(app)
+    end
+
+    def call(env)
+      env.request_headers['Token'] = token
+      logger.debug "Token set, headers: #{env.request_headers}"
+      @app.call(env)
+    end
+
+    private
+
+      attr_reader :options
+
+      # uses the token passed or fetches one only once
+      def token
+        @token ||= options[:token] || TokenFetcher.fetch(options[:token_url])
+      end
+  end
+end

--- a/lib/pdc/http/request/token_fetcher.rb
+++ b/lib/pdc/http/request/token_fetcher.rb
@@ -1,0 +1,32 @@
+require 'curb'
+require 'json'
+
+module PDC::Request
+  module TokenFetcher
+
+    # uses kerberos token to obtain token from pdc
+    def self.fetch(token_url)
+      PDC.logger.debug  "Fetch token from: #{token_url}"
+      curl = Curl::Easy.new(token_url.to_s) do |request|
+        request.headers['Accept'] = 'application/json'
+        request.http_auth_types = :gssnegotiate
+
+        # The curl man page (http://curl.haxx.se/docs/manpage.html)
+        # specifes setting a fake username when using Negotiate auth,
+        # and use ':' in their example.
+        request.username = ':'
+      end
+
+      curl.perform
+      if curl.response_code != 200
+        PDC.logger.info "Obtain token from #{token_url} failed: #{curl.body_str}"
+        error = { token_url: token_url, body: curl.body, code: curl.response_code }
+        raise PDC::TokenFetchFailed, error
+      end
+      result = JSON.parse(curl.body_str)
+      curl.close
+      result['token']
+    end
+
+  end
+end


### PR DESCRIPTION
This patch closes issue #7
  - moves token fetching to TokenFether module
  - adds middleware that fetches token on first request and caches it
  - tests to document the behaviour

JIRA: PDC-1683