### PR TITLE
Fix turning off SSL Verification

### DIFF
--- a/examples/test_no_ssl_verification.rb
+++ b/examples/test_no_ssl_verification.rb
@@ -1,0 +1,16 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+require 'ap'
+require 'pdc'
+
+def main
+  PDC.configure do |config|
+    config.site = 'https://pdc.engineering.redhat.com/'
+    config.log_level = :debug
+    config.ssl_verify_mode = OpenSSL::SSL::VERIFY_NONE
+  end
+
+  puts "Release count: #{PDC::V1::Release.count}"
+end
+
+main if __FILE__ == $PROGRAM_NAME

--- a/lib/pdc/http/request/pdc_token.rb
+++ b/lib/pdc/http/request/pdc_token.rb
@@ -24,7 +24,7 @@ module PDC::Request
 
       # uses the token passed or fetches one only once
       def token
-        @token ||= options[:token] || TokenFetcher.fetch(options[:token_url])
+        @token ||= options[:token] || TokenFetcher.fetch
       end
   end
 end

--- a/lib/pdc/http/request/token_fetcher.rb
+++ b/lib/pdc/http/request/token_fetcher.rb
@@ -4,23 +4,30 @@ require 'json'
 module PDC::Request
   module TokenFetcher
 
-    # uses kerberos token to obtain token from pdc
-    def self.fetch(token_url)
-      PDC.logger.debug  "Fetch token from: #{token_url}"
-      curl = Curl::Easy.new(token_url.to_s) do |request|
-        request.headers['Accept'] = 'application/json'
-        request.http_auth_types = :gssnegotiate
+    module Configuration
+      VALID_KEYS = [:ssl_verify_mode, :url].freeze
 
-        # The curl man page (http://curl.haxx.se/docs/manpage.html)
-        # specifes setting a fake username when using Negotiate auth,
-        # and use ':' in their example.
-        request.username = ':'
+      attr_accessor(*VALID_KEYS)
+
+      def options
+        Hash[*VALID_KEYS.map { |k| [k, send(k)] }.flatten]
       end
 
+      def configure
+        yield self
+      end
+    end
+    extend Configuration
+
+    # uses kerberos token to obtain token from pdc
+    def self.fetch
+      PDC.logger.debug "Fetch token from: #{url}"
+
+      curl = curl_easy
       curl.perform
       if curl.response_code != 200
-        PDC.logger.info "Obtain token from #{token_url} failed: #{curl.body_str}"
-        error = { token_url: token_url, body: curl.body, code: curl.response_code }
+        PDC.logger.info "Obtain token from #{url} failed: #{curl.body_str}"
+        error = { url: url, body: curl.body, code: curl.response_code }
         raise PDC::TokenFetchFailed, error
       end
       result = JSON.parse(curl.body_str)
@@ -28,5 +35,17 @@ module PDC::Request
       result['token']
     end
 
+    def self.curl_easy
+      Curl::Easy.new(url.to_s) do |request|
+        request.ssl_verify_peer    = ssl_verify_mode != OpenSSL::SSL::VERIFY_NONE
+        request.headers['Accept']  = 'application/json'
+        request.http_auth_types    = :gssnegotiate
+
+        # The curl man page (http://curl.haxx.se/docs/manpage.html)
+        # specifes setting a fake username when using Negotiate auth,
+        # and use ':' in their example.
+        request.username = ':'
+      end
+    end
   end
 end


### PR DESCRIPTION
This patch:
- removes config to turn off use_ssl (ssl used in all cases)
- all SSL peer verification to be turned off