### PR TITLE
Add known attributes to PDC::V1::Product

### DIFF
--- a/lib/pdc/v1/product.rb
+++ b/lib/pdc/v1/product.rb
@@ -1,4 +1,5 @@
 module PDC::V1
   class Product < PDC::Base
+    attributes :name, :short, :active, :product_versions, :internal
   end
 end


### PR DESCRIPTION
This patch fixes issue 22 where fetching a product resulted in
warning about unknown attributes. This has now been fixed by
adding the list of attributes to Product.