### PR TITLE
Fix travis pronto problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - git config --global user.name  "Travis CI"
 - git config --global user.email "pdc@product-definition-center.com"
 - export REPO_URL_GITHUB="https://$GH_TOKEN@github.com/$GH_REPO.git"
-- export GITHUB_ACCESS_TOKEN=$GH_TOKEN
+- export PRONTO_GITHUB_ACCESS_TOKEN=$GH_TOKEN
 script:
 - bundle exec rake test
 - >


### PR DESCRIPTION
Since the environment variable for pronto is changed
(https://github.com/mmozuras/pronto), it breaks current
travis CI check. Change it correspondingly.