### PR TITLE
Fix some existing pronto errors

### DIFF
--- a/examples/local_pdc_dev.rb
+++ b/examples/local_pdc_dev.rb
@@ -12,4 +12,4 @@ def main
   ap releases
 end
 
-main if __FILE__ == $PROGRAM_NAME
+main if $PROGRAM_NAME == __FILE__

--- a/examples/logger.rb
+++ b/examples/logger.rb
@@ -5,20 +5,15 @@ require 'ap'
 class FakeLogger
   attr_accessor :level
 
-  def debug(*args)
-  end
+  def debug(*args) end
 
-  def info(*args)
-  end
+  def info(*args) end
 
-  def warn(*args)
-  end
+  def warn(*args) end
 
-  def fatal(*args)
-  end
+  def fatal(*args) end
 
-  def error(*args)
-  end
+  def error(*args) end
 end
 
 # PDC.logger = FakeLogger.new
@@ -43,7 +38,7 @@ begin
       logger.error("Line in wrong format: #{line.chomp}")
     end
   end
-rescue => err
+rescue StandardError => err
   logger.fatal('Caught exception; exiting')
   logger.fatal(err)
 end

--- a/examples/pdc_release_rpm_mapping.rb
+++ b/examples/pdc_release_rpm_mapping.rb
@@ -15,4 +15,4 @@ def main
   puts mapping.mapping
 end
 
-main if __FILE__ == $PROGRAM_NAME
+main if $PROGRAM_NAME == __FILE__

--- a/examples/pdc_resource_tests.rb
+++ b/examples/pdc_resource_tests.rb
@@ -5,7 +5,7 @@ WebMock.disable! # this uses real server
 
 #### service config ####
 def token
-  script_path = File.expand_path(File.dirname(__FILE__))
+  script_path = File.expand_path(__dir__)
   token_path = File.join(script_path, '.token', 'pdc.prod')
   File.read(token_path).chomp.tap { |x| puts "Using token :#{x}" }
 rescue Errno::ENOENT => e

--- a/examples/pdc_test_cache.rb
+++ b/examples/pdc_test_cache.rb
@@ -46,4 +46,4 @@ def main
   end
 end
 
-main if __FILE__ == $PROGRAM_NAME
+main if $PROGRAM_NAME == __FILE__

--- a/examples/prod_failures.rb
+++ b/examples/prod_failures.rb
@@ -23,4 +23,4 @@ def main
   end
 end
 
-main if __FILE__ == $PROGRAM_NAME
+main if $PROGRAM_NAME == __FILE__

--- a/examples/prod_pdc.rb
+++ b/examples/prod_pdc.rb
@@ -11,4 +11,4 @@ def main
   ap releases
 end
 
-main if __FILE__ == $PROGRAM_NAME
+main if $PROGRAM_NAME == __FILE__

--- a/examples/test_no_ssl_verification.rb
+++ b/examples/test_no_ssl_verification.rb
@@ -13,4 +13,4 @@ def main
   puts "Release count: #{PDC::V1::Release.count}"
 end
 
-main if __FILE__ == $PROGRAM_NAME
+main if $PROGRAM_NAME == __FILE__

--- a/examples/url.rb
+++ b/examples/url.rb
@@ -7,11 +7,11 @@ PDC.configure do |config|
 end
 
 def main
-  rhel7_1 = PDC::V1::Release.find('rhel-7.1')
-  puts "release url : #{rhel7_1.url}"
-  rhel7_1.variants.all.each do |v|
+  rhel71 = PDC::V1::Release.find('rhel-7.1')
+  puts "release url : #{rhel71.url}"
+  rhel71.variants.all.each do |v|
     puts "release variant url : #{v.url}"
   end
 end
 
-main if __FILE__ == $PROGRAM_NAME
+main if $PROGRAM_NAME == __FILE__

--- a/lib/pdc.rb
+++ b/lib/pdc.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << File.expand_path(File.dirname(__FILE__))
+$LOAD_PATH << File.expand_path(__dir__)
 
 module PDC
   require 'pdc/version'

--- a/lib/pdc/http/request/token_fetcher.rb
+++ b/lib/pdc/http/request/token_fetcher.rb
@@ -4,7 +4,7 @@ require 'json'
 module PDC::Request
   module TokenFetcher
     module Configuration
-      VALID_KEYS = [:ssl_verify_mode, :url].freeze
+      VALID_KEYS = %i[ssl_verify_mode url].freeze
 
       attr_accessor(*VALID_KEYS)
 

--- a/lib/pdc/resource/attributes.rb
+++ b/lib/pdc/resource/attributes.rb
@@ -62,7 +62,7 @@ module PDC::Resource
         end
         @instance_method_container
       end
-    end # class methods
+    end
 
     def initialize(attributes = {})
       self.attributes = attributes

--- a/lib/pdc/resource/identity.rb
+++ b/lib/pdc/resource/identity.rb
@@ -34,7 +34,7 @@ module PDC::Resource
       def default_primary_key
         model_name.foreign_key.to_s
       end
-    end #  ClassMethods
+    end
 
     def id?
       attributes[primary_key].present?

--- a/lib/pdc/resource/relation/pagination.rb
+++ b/lib/pdc/resource/relation/pagination.rb
@@ -1,9 +1,9 @@
 module PDC::Resource
   PAGINATION = :pagination
-  PAGINATION_KEYS = [
-    :resource_count,
-    :previous_page,
-    :next_page
+  PAGINATION_KEYS = %i[
+    resource_count
+    previous_page
+    next_page
   ].freeze
 
   module Pagination

--- a/lib/pdc/resource/rest_api.rb
+++ b/lib/pdc/resource/rest_api.rb
@@ -29,7 +29,7 @@ module PDC::Resource
         query = params.except(*resource_path.variables)
         request(:get, uri, query)
       end
-    end # classmethod
+    end
 
     def initialize(attr = {})
       super

--- a/lib/pdc/resource/scopes.rb
+++ b/lib/pdc/resource/scopes.rb
@@ -20,7 +20,7 @@ module PDC::Resource
       def current_scope
         ScopeRegistry.value_for(:current_scope, name)
       end
-    end # class methods
+    end
 
     def scoped
       self.class.scoped

--- a/pdc.gemspec
+++ b/pdc.gemspec
@@ -1,5 +1,5 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
+
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'pdc/version'
 
@@ -16,24 +16,22 @@ Gem::Specification.new do |s|
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
-  if s.respond_to?(:metadata)
-    s.metadata['allowed_push_host'] = 'https://rubygems.org'
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
-  end
+  raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.' \
+      unless s.respond_to?(:metadata)
 
+  s.metadata['allowed_push_host'] = 'https://rubygems.org'
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'activesupport', '~> 3.2.22.2'
   s.add_dependency 'activemodel', '~> 3.2.22.2'
-  s.add_dependency 'uri_template', '~> 0.7.0'
-  s.add_dependency 'multi_json', '~> 1.11'
+  s.add_dependency 'activesupport', '~> 3.2.22.2'
   s.add_dependency 'faraday', '~> 0.9.2'
-  s.add_dependency 'faraday_middleware', '~> 0.10.0'
   s.add_dependency 'faraday-http-cache', '~> 1.3.0'
+  s.add_dependency 'faraday_middleware', '~> 0.10.0'
+  s.add_dependency 'multi_json', '~> 1.11'
+  s.add_dependency 'uri_template', '~> 0.7.0'
   # redhat sudo yum install ruby-devel libcurl-devel openssl-devel
   # ubuntu sudo apt-get install libcurl3 libcurl3-gnutls libcurl4-openssl-dev
   s.add_dependency 'curb', '~> 0.9.3'

--- a/spec/pdc/resource/attributes_spec.rb
+++ b/spec/pdc/resource/attributes_spec.rb
@@ -106,7 +106,7 @@ end
 
 describe 'nested hash attributes' do
   it 'returns OpenStruct for nested hash' do
-    allowed_tags = %w(foo bar baz)
+    allowed_tags = %w[foo bar baz]
     stub_get('nested-models/1').to_return_json(
       data: [{
         id: 1, name: 'RHEL',

--- a/spec/pdc/resource/cache_spec.rb
+++ b/spec/pdc/resource/cache_spec.rb
@@ -71,7 +71,7 @@ describe 'Caching' do
       PDC::V1::Release.page(2).page_size(30).contents!
       PDC::V1::Release.page(2).page_size(30).contents!
     end
-    cache.must_equal [:miss, :fresh]
+    cache.must_equal %i[miss fresh]
   end
 
   it 'caches multiple response' do

--- a/spec/pdc/resource/path_spec.rb
+++ b/spec/pdc/resource/path_spec.rb
@@ -13,7 +13,7 @@ describe PDC::Resource::Path do
     path = subject.new('/users/:user_id/recipes/(:id)',
                        user_id: 1, status: 'published')
 
-    assert_equal [:user_id, :id], path.variables
+    assert_equal %i[user_id id], path.variables
     assert_equal '/users/1/recipes', path.expanded
   end
 

--- a/spec/pdc/v1/content_delivery_repo_spec.rb
+++ b/spec/pdc/v1/content_delivery_repo_spec.rb
@@ -11,8 +11,9 @@ describe PDC::V1::ContentDeliveryRepo do
 
   describe 'count' do
     it 'has serveral cdn content delivery repos' do
-      content_delivery_repos = PDC::V1::ContentDeliveryRepo
-				.where(release_id: 'ceph-2.1-updates@rhel-7', service: 'pulp')
+      content_delivery_repos = PDC::V1::ContentDeliveryRepo.where(
+        release_id: 'ceph-2.1-updates@rhel-7', service: 'pulp'
+      )
       assert_equal 18, content_delivery_repos.count
     end
   end
@@ -20,13 +21,12 @@ describe PDC::V1::ContentDeliveryRepo do
   describe 'find' do
     it 'content delivery repos must return a record' do
       repo_class = PDC::V1::ContentDeliveryRepo
-      existing_repo = PDC::V1::ContentDeliveryRepo
-			.where(release_id: 'ceph-2.1-updates@rhel-7', service: 'pulp')
-			.first
+      existing_repo = PDC::V1::ContentDeliveryRepo.where(
+        release_id: 'ceph-2.1-updates@rhel-7', service: 'pulp'
+      ).first
       found = repo_class.find(existing_repo.id)
       found.must_be_instance_of repo_class
       found.name.must_equal existing_repo.name
     end
   end
 end
-

--- a/spec/pdc/v1/release_spec.rb
+++ b/spec/pdc/v1/release_spec.rb
@@ -25,10 +25,10 @@ describe PDC::V1::Release do
     end
 
     it 'can get release by multi product_version' do
-      count = release.where(product_version: ["rhel-8","rhel-7"]).count
+      count = release.where(product_version: ['rhel-8', 'rhel-7']).count
       count.must_equal 8
     end
-  end #  count
+  end
 
   describe '#brew' do
     it 'brew can be nil' do
@@ -45,27 +45,27 @@ describe PDC::V1::Release do
       allowed_tags = rhel_6_sat.brew.allowed_tags
       allowed_tags.first.must_equal 'satellite-6.2.0-rhel-6'
     end
-  end #  brew
+  end
 
   describe '#variants' do
     it 'fetches variants of a release' do
-      rhel7_1 = release.find('rhel-7.1')
-      variants = rhel7_1.variants.all
+      rhel71 = release.find('rhel-7.1')
+      variants = rhel71.variants.all
       variants.length.must_equal 12
       releases = variants.map(&:release)
-      releases.must_equal [rhel7_1] * variants.length
+      releases.must_equal [rhel71] * variants.length
     end
   end
 
   describe '#url' do
     it 'returns url of a release' do
-      rhel7_1 = release.find('rhel-7.1')
-      rhel7_1.url.must_equal(PDC_SITE + 'rest_api/v1/releases/rhel-7.1')
+      rhel71 = release.find('rhel-7.1')
+      rhel71.url.must_equal(PDC_SITE + 'rest_api/v1/releases/rhel-7.1')
     end
 
     it 'returns url of a release_variant' do
-      rhel7_1 = release.find('rhel-7.1')
-      rhel7_1.variants.all.each do |v|
+      rhel71 = release.find('rhel-7.1')
+      rhel71.variants.all.each do |v|
         v.url.must_equal(PDC_SITE + 'rest_api/v1/release%2Dvariants/rhel-7.1/' + v.uid)
       end
     end


### PR DESCRIPTION
Fix some pronto errors like:

1. examples/local_pdc_dev.rb:15:9:
C: Style/YodaCondition: Reverse the order of the operands __FILE__ == $PROGRAM_NAME.
(https://en.wikipedia.org/wiki/Yoda_conditions) main if __FILE__ == $PROGRAM_NAME

2. examples/logger.rb:8:3:
C: Style/EmptyMethod: Put empty method definitions on a single line.
(https://github.com/bbatsov/ruby-style-guide#no-single-line-methods)
def debug(*args) ...

3. spec/pdc/resource/path_spec.rb:16:18:
C: Style/SymbolArray: Use %i or %I for an array of symbols.
(https://github.com/bbatsov/ruby-style-guide#percent-i)
assert_equal [:user_id, :id], path.variables

4. spec/pdc/v1/release_spec.rb:31:7:
C: Style/CommentedKeyword: Do not place comments on the same line as the end keyword.
end #  count
...