### PR TITLE
Add a PRONTO_GITHUB_ACCESS_TOKEN before pronto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 - bundle exec rake test
 - >
   if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-    bundle exec pronto run -f github_pr -c origin/${TRAVIS_BRANCH}
+    PRONTO_GITHUB_ACCESS_TOKEN=$PROACCESS pronto run -f github_pr -c origin/${TRAVIS_BRANCH}
   fi
 
 after_success:


### PR DESCRIPTION
Add a PRONTO_GITHUB_ACCESS_TOKEN before pronto
to forbid 403 error when visit github api.
And if you want use the secure in .travis.yml or use the Env vars in travis  ci's settings, you shouldn't commit codes from a fork.