### PR TITLE
Change the pronto to rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
+  Exclude:
+    - bin/console
 
 Style/Documentation:
   Enabled: false
@@ -8,6 +10,10 @@ Style/Documentation:
 Style/ClassAndModuleChildren:
   Enabled: false
   EnforcedStyle: compact
+
+Style/MethodMissing:
+  Exclude:
+    - lib/pdc/resource/per_thread_registry.rb 
 
 Metrics/LineLength:
   Max: 100
@@ -20,6 +26,8 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 25
+  Exclude:
+    - lib/pdc/config.rb
 
 Metrics/BlockLength:
   Max: 100
@@ -30,3 +38,7 @@ Metrics/BlockLength:
 Naming/PredicateName:
   Enabled: false
 
+Metrics/ModuleLength:
+  Exclude:
+    - lib/pdc/config.rb
+        

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ script:
 - bundle exec rake test
 - >
   if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-    bundle exec pronto run -f github_pr -c origin/${TRAVIS_BRANCH}
+    bundle exec rubocop 
   fi
-
 after_success:
 - >
   [ "$TRAVIS_BRANCH" = "master" ] &&

--- a/examples/logger.rb
+++ b/examples/logger.rb
@@ -34,9 +34,7 @@ path = 'a_non_existent_file'
 
 begin
   File.foreach(path) do |line|
-    unless line =~ /^(\w+) = (.*)$/
-      logger.error("Line in wrong format: #{line.chomp}")
-    end
+    logger.error("Line in wrong format: #{line.chomp}") unless line =~ /^(\w+) = (.*)$/
   end
 rescue StandardError => err
   logger.fatal('Caught exception; exiting')

--- a/examples/pdc_resource_tests.rb
+++ b/examples/pdc_resource_tests.rb
@@ -23,7 +23,7 @@ server = {
 
   prod: {
     site: 'https://pdc.engineering.redhat.com',
-    token: ->() { token } # read token only if needed
+    token: -> { token } # read token only if needed
   }
 }
 

--- a/lib/pdc/config.rb
+++ b/lib/pdc/config.rb
@@ -1,7 +1,6 @@
 require 'faraday-http-cache'
 require 'pdc/http/request/token_fetcher'
 
-# rubocop:disable ModuleLength
 module PDC
   # This class is the main access point for all PDC::Resource instances.
   #
@@ -23,17 +22,13 @@ module PDC
     Config = Struct.new(
       :site,
       :api_root,
-
       :ssl_verify_mode,
-
       :requires_token,
       :token_obtain_path,
       :token,
-
       :log_level,
       :enable_logging,
       :logger,
-
       :cache_store,
       :disable_caching
     ) do
@@ -76,7 +71,6 @@ module PDC
     def config=(new_config)
       @config = new_config
       apply_config
-      @config
     end
 
     def token_url
@@ -113,7 +107,6 @@ module PDC
     end
 
     # resets and returns the +Faraday+ +connection+ object
-    # rubocop:disable AbcSize
     def reset_base_connection
       faraday_config = {
         url:      api_url,

--- a/lib/pdc/http/response/pagination.rb
+++ b/lib/pdc/http/response/pagination.rb
@@ -13,10 +13,8 @@ module PDC::Response
 
       metadata[PDC::Resource::PAGINATION] = {
         resource_count:   metadata.delete(:count),
-
         # TODO: decide if this is okay to discard the
         # schema://host:port/ of the next and previous
-
         next_page:        request_uri(metadata.delete(:next)),
         previous_page:    request_uri(metadata.delete(:previous))
       }

--- a/lib/pdc/resource/relation.rb
+++ b/lib/pdc/resource/relation.rb
@@ -70,6 +70,10 @@ module PDC::Resource
       with_scope { klass.send(name, *args, &block) }
     end
 
+    def respond_to_missing?(name)
+      klass.respond_to? name
+    end
+
     # Keep hold of current scope while running a method on the class
     def with_scope
       previous = klass.current_scope

--- a/spec/pdc/resource/attributes_spec.rb
+++ b/spec/pdc/resource/attributes_spec.rb
@@ -20,15 +20,15 @@ end
 
 describe PDC::Resource::Attributes do
   it 'returns all attributes' do
-    Product.attributes.wont_be_empty
+    Fixtures::Product.attributes.wont_be_empty
   end
 
   it 'primary_key will be in attributes by default' do
-    Product.attributes.must_include Product.primary_key
+    Fixtures::Product.attributes.must_include Fixtures::Product.primary_key
   end
 
   it 'allows block initialization' do
-    prod = Product.new do |p|
+    prod = Fixtures::Product.new do |p|
       p.name = 'RHEL'
       p.description = 'Enterprise Linux'
     end
@@ -38,12 +38,12 @@ describe PDC::Resource::Attributes do
 
   it 'can handle predicate' do
     stub_get('products/1').to_return_json(data: [{ id: 1, name: 'RHEL' }])
-    product = Product.find(1)
+    product = Fixtures::Product.find(1)
     assert_equal true, product.name?
   end
 
   it 'can assign a hash' do
-    product = Product.new(id: 2)
+    product = Fixtures::Product.new(id: 2)
     product.attributes = { name: 'RHEL' }
 
     product.name.must_equal 'RHEL'
@@ -51,24 +51,24 @@ describe PDC::Resource::Attributes do
   end
 
   it 'can get and set value' do
-    product = Product.new
+    product = Fixtures::Product.new
     product.name = 'RHEL'
     product.name.must_equal 'RHEL'
   end
 
   it 'works with []' do
-    product = Product.new(name: 'Fedora')
+    product = Fixtures::Product.new(name: 'Fedora')
     product[:name].must_equal 'Fedora'
   end
 
   it 'works with []=' do
-    product = Product.new
+    product = Fixtures::Product.new
     product[:name] = 'bar'
     product.name.must_equal 'bar'
   end
 
   it 'allows assigning unknown attributes' do
-    product = Product.new
+    product = Fixtures::Product.new
 
     product.wont_respond_to :foobar
     product.must_respond_to :foobar=
@@ -80,7 +80,7 @@ describe PDC::Resource::Attributes do
   it 'return error when no such method' do
     stub_get('products/1').to_return_json(data: [{ id: 1, name: 'RHEL' }])
 
-    product = Product.find(1)
+    product = Fixtures::Product.find(1)
     assert_raises NoMethodError do
       product.no_such_thing?
     end
@@ -93,24 +93,24 @@ describe PDC::Resource::Attributes do
     it 'returns true for known attributes' do
       stub_get('products/1').to_return_json(data: [{ id: 1, name: 'RHEL' }])
 
-      product = Product.find(1)
+      product = Fixtures::Product.find(1)
       product.must_respond_to :name
     end
 
     it 'returns false for unknown attributes that are not set' do
       stub_get('products/1').to_return_json(data: [{ id: 1, name: 'RHEL' }])
 
-      product = Product.find(1)
+      product = Fixtures::Product.find(1)
       product.wont_respond_to :title
     end
 
     it 'returns true for unknown attributes after it is set' do
-      product = Product.new
+      product = Fixtures::Product.new
       product.wont_respond_to :foobar
 
       product.foobar = 'bar'
       product.must_respond_to :foobar
-      Product.attributes.wont_include :foobar
+      Fixtures::Product.attributes.wont_include :foobar
     end
   end
 end
@@ -128,7 +128,7 @@ describe 'nested hash attributes' do
       }]
     )
 
-    model = NestedModel.find(1)
+    model = Fixtures::NestedModel.find(1)
     model.must_respond_to :nested
     model.nested.must_be_instance_of OpenStruct
     model.nested.must_respond_to :tag
@@ -149,7 +149,7 @@ describe 'nested hash attributes' do
       }]
     )
 
-    model = NestedModel.find(1)
+    model = Fixtures::NestedModel.find(1)
     model.must_respond_to :nested
 
     model.nested.must_respond_to :second_level
@@ -168,7 +168,7 @@ describe 'nested hash attributes' do
       }]
     )
 
-    model = NestedModel.find(1)
+    model = Fixtures::NestedModel.find(1)
     model.must_respond_to :unregistered_nested
     model.unregistered_nested.must_be_instance_of OpenStruct
     model.unregistered_nested.must_respond_to :value
@@ -177,7 +177,7 @@ describe 'nested hash attributes' do
 end
 
 describe 'Custom ValueParser' do
-  subject { CustomParserModel }
+  subject { Fixtures::CustomParserModel }
   it 'must return fixnum for age' do
     stub_get('custom-parser-models/1').to_return_json(
       data: [{
@@ -187,7 +187,6 @@ describe 'Custom ValueParser' do
 
     model = subject.find(1)
     model.must_respond_to :age
-    model.age.must_be_instance_of Fixnum
     model.age.must_equal 20
   end
 end

--- a/spec/pdc/resource/identity_spec.rb
+++ b/spec/pdc/resource/identity_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 require 'ap'
 
-describe ModelWithIdentity do
-  subject { ModelWithIdentity }
+describe Fixtures::ModelWithIdentity do
+  subject { Fixtures::ModelWithIdentity }
 
   describe '##primary_key' do
     it 'must exist' do
@@ -43,8 +43,8 @@ describe ModelWithIdentity do
   end
 end
 
-describe CustomPrimaryKeyModel do
-  subject { CustomPrimaryKeyModel }
+describe Fixtures::CustomPrimaryKeyModel do
+  subject { Fixtures::CustomPrimaryKeyModel }
 
   describe '##primary_key' do
     it 'can be set' do
@@ -66,8 +66,8 @@ describe CustomPrimaryKeyModel do
   end
 end
 
-describe V1::Foobar do
-  subject { V1::Foobar }
+describe Fixtures::V1::Foobar do
+  subject { Fixtures::V1::Foobar }
   it 'must have a pkey' do
     subject.primary_key.must_equal 'foobar_id'
   end
@@ -79,15 +79,15 @@ end
 
 describe 'attributes' do
   it 'base must have primary key' do
-    ModelBase.new.id.must_be_nil
-    base = ModelBase.new(model_base_id: 1)
+    Fixtures::ModelBase.new.id.must_be_nil
+    base = Fixtures::ModelBase.new(model_base_id: 1)
     base.id.must_equal 1
     base.attributes.must_include :model_base_id
   end
 
   it 'sub must not have primary key of base' do
-    Model.new.id.must_be_nil
-    model = Model.new(model_id: 3)
+    Fixtures::Model.new.id.must_be_nil
+    model = Fixtures::Model.new(model_id: 3)
     model.id.must_equal 3
     model.attributes.must_include :model_id
     model.attributes.wont_include :model_base_id

--- a/spec/pdc/resource/relation_spec.rb
+++ b/spec/pdc/resource/relation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-class SearchableModel < Base
+class SearchableModel < Fixtures::Base
   attributes :name, :product
 
   ### NOTE: where() will have no impact since the data is hardcoded

--- a/spec/pdc/v1/global_component_contact_spec.rb
+++ b/spec/pdc/v1/global_component_contact_spec.rb
@@ -18,7 +18,7 @@ describe PDC::V1::GlobalComponentContact do
   describe 'count' do
     it 'must return number of resources' do
       count = contact.count
-      count.must_equal 12546
+      count.must_equal 12_546
     end
 
     it 'works with where' do

--- a/spec/pdc/v1/release_variant_spec.rb
+++ b/spec/pdc/v1/release_variant_spec.rb
@@ -17,11 +17,10 @@ describe PDC::V1::ReleaseVariant do
     attributes.must_include :variant_version, :variant_release
   end
 
-  it 'returns cpe' do 
+  it 'returns cpe' do
     variant = cpe_variant.first
     cpe = variant.cpe
-    cpe.variant_uid.must_equal "Calamari"
-    cpe.cpe.must_equal "cpe:test"
+    cpe.variant_uid.must_equal 'Calamari'
+    cpe.cpe.must_equal 'cpe:test'
   end
-
 end

--- a/spec/pdc/v1/variant_cpe_spec.rb
+++ b/spec/pdc/v1/variant_cpe_spec.rb
@@ -20,9 +20,9 @@ describe PDC::V1::VariantCpe do
     end
 
     it 'cpe works with where' do
-      count = cpe.where(cpe: "cpe:test").count
+      count = cpe.where(cpe: 'cpe:test').count
       count.must_equal 1
-      count = cpe.where(variant_uid: "Calamari").count
+      count = cpe.where(variant_uid: 'Calamari').count
       count.must_equal 1
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,3 @@ PDC.configure do |config|
   config.disable_caching = true
   ###  config.log_level = :debug   # enable to see details log
 end
-
-# TODO: decide if this is okay to do
-include Fixtures


### PR DESCRIPTION
1. Change the pronto to rubocop to reduce the times of calling github apis and forbid the 403 errors in travis.
2. fix the format issues.

Even we add a PRONTO_GITHUB_ACCESS_TOKEN, when we create pr from a fork, there should occur errors because the Env Vars doesn't work for forks, https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions , so close pr #48, and create this patch.

And the flay doesn't work when calling the pronto, so here I just add a rubocop command.